### PR TITLE
Matplotlib use qt5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@
 language: python
 
 python:
-  #- "3.4"
-  - "2.7"
+  - "3.5"
 
 install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION --file requirements.txt
   - source activate test-environment
+  - pip install git+https://github.com/pyqtgraph/pyqtgraph@develop
   - python setup.py install
 
 script: python setup.py test

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ PyMoskito
 =========
 
 .. image:: https://img.shields.io/travis/cklb/pymoskito.svg
-        :target: https://travis-ci.org/freddy_k/pymoskito
+        :target: https://travis-ci.org/cklb/pymoskito
 
 .. image:: https://img.shields.io/pypi/v/pymoskito.svg
         :target: https://pypi.python.org/pypi/pymoskito

--- a/pymoskito/generic_processing_modules.py
+++ b/pymoskito/generic_processing_modules.py
@@ -2,6 +2,7 @@
 
 
 import matplotlib as mpl
+mpl.use('Qt5Agg')
 import numpy as np
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ with open('requirements.txt') as requirements_file:
     requirements = requirements_file.read()
 
 test_requirements = [
-    'unittest'
 ]
 
 setup(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from pymoskito import *


### PR DESCRIPTION
Without the line from 4a1932b i get

```
/home/marcus/anaconda2/envs/pymoskitoenv/bin/python /home/marcus/Dokumente/Projekte/PyMoskito/pymoskito/examples/balltube/__main__.py
Traceback (most recent call last):
  File "/home/marcus/Dokumente/Projekte/PyMoskito/pymoskito/examples/balltube/__main__.py", line 6, in <module>
    import pymoskito as pm
  File "/home/marcus/Dokumente/Projekte/PyMoskito/pymoskito/__init__.py", line 5, in <module>
    from .generic_processing_modules import StepResponse, PlotAll, XYMetaProcessor, construct_result_dict
  File "/home/marcus/Dokumente/Projekte/PyMoskito/pymoskito/generic_processing_modules.py", line 7, in <module>
    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
  File "/home/marcus/anaconda2/envs/pymoskitoenv/lib/python3.5/site-packages/matplotlib/backends/backend_qt5agg.py", line 15, in <module>
    from .backend_qt5 import QtCore
  File "/home/marcus/anaconda2/envs/pymoskitoenv/lib/python3.5/site-packages/matplotlib/backends/backend_qt5.py", line 31, in <module>
    from .qt_compat import QtCore, QtGui, QtWidgets, _getSaveFileName, __version__
  File "/home/marcus/anaconda2/envs/pymoskitoenv/lib/python3.5/site-packages/matplotlib/backends/qt_compat.py", line 124, in <module>
    from PyQt4 import QtCore, QtGui
ImportError: No module named 'PyQt4'

Process finished with exit code 1
```

inside the conda environment: [conda_env.txt](https://github.com/cklb/pymoskito/files/531108/conda_env.txt).
